### PR TITLE
fix: Add missing comma in slash commands workflow

### DIFF
--- a/.github/workflows/slash.yml
+++ b/.github/workflows/slash.yml
@@ -37,7 +37,7 @@ jobs:
               "permission": "write",
               "issue_type": "pull-request",
               "repository": "tektoncd/pipeline"
-            }
+            },
             {
               "command": "e2e-extras",
               "permission": "write",


### PR DESCRIPTION
# Changes

This PR fixes a syntax error in the slash commands workflow configuration by adding a missing trailing comma after the first slash command definition.

The comma was missing on line 40 after the closing brace of the first command object, which could potentially cause workflow parsing issues.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```